### PR TITLE
docs(readme): 翻訳の分担方法の説明を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,8 @@ design ディレクトリ内にある英文を翻訳していきます。
 
 ブラウザ上で翻訳したいmdファイルをクリックし、鉛筆マークの「Edit this file」をクリックすることでブラウザ上でも更新（プルリクエスト）できます。
 
-翻訳の提案は、このデザインハンドブックでは **プルリクのみで OK** です。
-
-担当してみたい箇所を一人で時間をかけて翻訳したいなどのご希望がありましたら、 [WordPress 日本語 Slack](http://bit.ly/join-wordslack) の design チャンネルまでご相談ください。
+翻訳の分担は、このデザインハンドブックでは [Issue で管理](https://github.com/miminari/design-handbook/issues?q=is%3Aissue+is%3Aopen+label%3A%22in+progress%22)しています。
+翻訳したいページの Issue がすでに立っていないかを確認後、新たに[翻訳用の Issue をテンプレートに沿って作成](https://github.com/miminari/design-handbook/issues/new?template=translate-issue-template.md)してください。
 
 GitHub が初めての方も [翻訳開始から提案までの流れ](https://github.com/jawordpressorg/community-handbook/wiki/%E7%BF%BB%E8%A8%B3%E9%96%8B%E5%A7%8B%E3%81%8B%E3%82%89%E6%8F%90%E6%A1%88%E3%81%BE%E3%81%A7%E3%81%AE%E6%B5%81%E3%82%8C) を参考に、是非ご参加ください。
 


### PR DESCRIPTION
Issueで管理することを明記しました。