### PR TITLE
add design-table-facilitator-guidelines

### DIFF
--- a/design/get-involved/leading-a-contribution-day/design-table-facilitator-guidelines.md
+++ b/design/get-involved/leading-a-contribution-day/design-table-facilitator-guidelines.md
@@ -1,0 +1,88 @@
+# Design Table Facilitator Guidelines
+
+This page outlines a baseline format to run the Design Table during WordCamp Contributor Days. It’s not meant to be followed strictly, but it’s a useful guideline especially for people that are running the table for the first time.  
+
+The idea is to have clear instructions that anyone with some degree of knowledge of the WordPress design work can follow. Also, having these as a written guideline allows for improvements over time and future tweaks for different contexts.  
+
+The guiding principles for this is to have them **connected to the global community** and show them in a **practical way how to contribute**.  
+
+# **Plan**
+
+Facilitating the Design Table work during Contributor Day isn’t a difficult task but takes some experience with the community and it can be very intense on the day.  
+
+We suggest to have at least direct experience of these:
+
+*   Have participated at least once in a Design Triage chat in [design](https://wordpress.slack.com/messages/design/) Slack.
+*   Have practice of the tools used during the day (Slack, Trac, GitHub, Trello, …).
+*   Have contributed to at least a couple of tickets (Trac, optionally GitHub and others).
+
+### **Before Contributor Day**
+
+Overall the preparation work shouldn’t take more than a few hours among the various things, and gets easier the more you do it.  
+
+1.  **Review task sources** — during the contributor day we want to propose to the table a series of activities that can be taken up by individuals and groups. This means that the Facilitator should have reviewed the list of possible tasks and should already have an idea on at least some of them, so they don’t have to catch up on the day.  The list can get long, so don’t try to know review everything, but cover enough items to be able to provide an example to the group.
+    1.  **Trac** — review the [needs ‘ui-feedback’ and ‘ux-feedback’ tags](https://core.trac.wordpress.org/report/35?sort=modified&asc=1&page=1) and make sure there are good tickets for the discussion. Try to have 2-3 simple ones ready you know in detail to use as examples for contribution.
+    2.  **GitHub** — if there are projects that are currently being worked on in WordPress but are currently tracked on GitHub (i.e. [Gutenberg’s ‘Needs Design Feedback’](https://github.com/WordPress/gutenberg/issues?q=is%3Aopen+is%3Aissue+label%3A%22Needs+Design+Feedback%22)), review these issues too.
+    3.  **Trello** — review existing tasks on the [design board](https://trello.com/b/fnHScayo/design-team) to find items that can be picked up and either completed or at least iterated upon during the day.
+2.  **Logistics** — ask the details about the space during contributor day.
+    1.  Ask how many designers are expected to join.
+    2.  It’s ideal if there’s a wall for post-its or a whiteboard. If that’s available, get post-its and markers with a medium-sized tip (like Sharpies).
+    3.  Review start and end time of the Contributor Day, and specifically start and end work of the tables (as there’s an intro and a closing remarks which will can take about 30 minutes each).
+    4.  See if the space allows for having a separate room and/or a projector. This can be very useful to guide people through.
+3.  **Rehearse** — read the Day Outline below, and try out, maybe even speaking aloud, what you’re going to say. Have a read of the [design about page](https://make.wordpress.org/design/handbook/about-the-team/) for extra reference.
+4.  **Rest** — be sure to have good rest the day before, and prepare supplies to have with you during the day (i.e. water, snacks, etc).
+5.  **Don’t go alone** — consider having someone to support you facilitating, this becomes more important as you get a large amount of contributor.
+
+### **Day Outline**
+
+Be ready for an intense day that will also flow really fast. Each of the tasks here can take a lot of time, so make sure to not spend too much time on setup and logistics and try to get people on actual work quickly. For large group this might need more than one facilitator, or cut down in setup time. Remember: the idea is to have people contribute in the long run, and do something they can feel good about on the day.  
+
+Also, be ready for internet to be down. It often happens with so many people joining. In the preparation above it may be helpful to save full screenshots of 2-3 issues for discussion if internet goes down. .  
+
+1.  Contributor Day Intro
+    1.  Before the work at the table starts, the design table Facilitator usually prepares a short introduction to be given on stage, explaining who they are and what they are going to do on the day, and inviting people to join the design table.
+    2.  The Facilitator also invites other tables to come to the design table if they need design help.
+2.  Design Table Intro
+    1.  Thank people for joining.
+    2.  Explain how design contributes to WordPress.
+    3.  Give a general outline of the work the group is going to do today (loose agenda, tasks, etc).
+3.  Ice Breaker / Intro People
+    1.  Have everyone introduce themselves briefly: **name**, where they are **from**, their **job** title.
+        *   If you have a wall and post-its: have everyone draw their own portrait (stylized! do it first as an example) and under it name and job title. Everyone then says hello while putting their post-it on the wall.
+    2.  You can also run a quick ice-breaker if there’s time ([examples](http://gamestorming.com/category/icebreakers/)).
+4.  Setup
+    1.  Explain how these communication tools (Slack, Trello) are used to collaborate on WordPress, and then help them setup. Tell everyone to say “Hi” in the [design](https://wordpress.slack.com/messages/design/) Slack channel once they have completed setting up.
+    2.  For the setup, Slack is the most important part as it allows people to be in touch with the community after the Contributor Day. As the setup can take a lot of time, you can choose to ignore other setups to focus on Slack.
+    3.  Slack
+        *   Invite:  
+            [https://make.wordpress.org/chat/](https://make.wordpress.org/chat/)  
+    4.  Trello
+        *   Invite:  
+            [https://trello.com/invite/b/fnHScayo/ed40e89e3bd2e876975fbbc1175e3084/design-team](https://trello.com/invite/b/fnHScayo/ed40e89e3bd2e876975fbbc1175e3084/design-team)  
+    5.  Staging Setup
+        *   Depending on the tasks, it can be useful for everyone to have a local test installation of WordPress to work with. This can take a long time to setup, and an available internet connection, so be careful in this specific task as it can take a lot of time (and without internet might not be possible at all).
+        *   The easiest way might be to use  [MAMP](https://www.mamp.info/en/downloads/).
+        *   If they don’t want to have a local install and internet works, you can suggest to use [http://poopy.life/](http://poopy.life/).
+    6.  While people create accounts
+        *   Email — go around and ask for their email to know if they are willing to receive a survey after the Contributor Day. Make sure this email is used only once, and only for the survey (for privacy reasons).
+        *   Prepare Tasks — if there’s a whiteboard or a wall available put post-its on it in a row, one post-it for each work category (i.e. Testing, Triage, Trello, etc). Leave space below so people can move their “portrait” post-it under the specific column to signal they will work on it.
+5.  Triage Simulation
+    1.  Once everyone is in Slack, do a design triage simulation (i.e. one or two tickets you’ve prepared before, not all of them).
+    2.  If possible and time zones are available, have someone remote join the discussion. You might have to arrange this beforehand.
+    3.  The idea here is to have them experience as close as possible how the weekly design triage works, so they are comfortable in contributing the next time it happens.
+    4.  See [here for an example](https://wordpress.slack.com/archives/C02S78ZAL/p1536889396000100).
+6.  Tasks Explanation
+    1.  If you have prepared the columns with post-its on the wall, ask people to move their “portrait” post-it under the column they want to work with. If not, call out each task and have people raise their hand to organize the groups.
+    2.  Have people that will work on the same tasks sit together (i.e. all the people doing testing, all the people reviewing issues, etc).
+    3.  Have the people start working. Go around each group one at time and get them started.
+7.  Check In
+    1.  Set a time, likely after lunch break, to regroup. It should be halfway through the day. It doesn’t have to be a group activity, it can also be simply going around person by person or group by group and ask how they are progressing and see if you can clarify things.
+8.  Collect Work Done
+    1.  Be sure you know exactly when the closing remarks for the Contributor Day will happen.
+    2.  About 30 minutes before, go around each group and collect the work they have done during the day in order to present it.
+9.  End of Day Summary
+    1.  At the end you’ll be likely be asked to do a recap of the work done at the design table. These are informations that are useful to summarize:
+        1.  How many contributors?
+        2.  How many people onboarded (i.e. on [#design](https://make.wordpress.org/design/tag/design/) Slack)?
+        3.  What activities were done (i.e. what were the different groups)?
+        4.  Any highlight?


### PR DESCRIPTION
原文に新しいページが追加されたので、更新します。

参照URL：
https://make.wordpress.org/design/2018/11/27/facilitating-a-contribution-day-for-design-handbook-update/